### PR TITLE
Guard against Promote after RLock

### DIFF
--- a/motex.go
+++ b/motex.go
@@ -41,6 +41,8 @@ import (
 type Motex struct {
 	w sync.Mutex   // Blocks writes.
 	r sync.RWMutex // Blocks reads.
+
+	g sync.Mutex // Guards against Promote after RLock.
 }
 
 // Lock locks m for writing. If the lock is already locked for reading or
@@ -69,6 +71,8 @@ func (m *Motex) Unlock() {
 func (m *Motex) Demote() {
 	m.r.Unlock()
 	m.r.RLock()
+
+	m.g.Lock()
 }
 
 // Promote promotes m from a Demoted() Lock() to a lock for writing, blocking
@@ -81,6 +85,8 @@ func (m *Motex) Demote() {
 func (m *Motex) Promote() {
 	m.r.RUnlock()
 	m.r.Lock()
+
+	m.g.Unlock()
 }
 
 // RLock locks m for reading. If the lock is already locked for writing or

--- a/motex_test.go
+++ b/motex_test.go
@@ -332,6 +332,14 @@ var misuseTests = []struct {
 			mo.Demote()
 		},
 	},
+	{
+		name: "Promote after RLock",
+		f: func() {
+			var mo Motex
+			mo.RLock()
+			mo.Promote()
+		},
+	},
 }
 
 func TestMotexMisuse(t *testing.T) {


### PR DESCRIPTION
Calling `Promote()` after `RLock()` does not result in a run-time error like it should. This PR adds another mutex to guard against this. Will not merge until there are benchmarks to show the impact of adding another mutex.

Note that it might seem valid to promote an RLock. But in fact this:
```go
var mo motex.Motex
mo.RLock()
copied := state
mo.Promote()
state = copied + 1
mo.Demote()
mo.RUnlock()
```
is equivalent to this:
```go
var mu synt.Mutex
mu.RLock()
copied := state
mu.RUnlock()
mu.Lock()
state = copied + 1
mu.Unlock()
```
which is non-atomic.